### PR TITLE
Nissix plugin scope-packages on draft-convert

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "bbriggs@hubspot.com",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "draft-js": ">=0.7.0",
+    "@wix/draft-js": ">=0.7.0",
     "react": "^15.0.2|| ^16.0.0-rc || ^16.0.0",
     "react-dom": "^15.0.2|| ^16.0.0-rc || ^16.0.0"
   },
@@ -53,7 +53,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "cross-env": "^3.1.4",
-    "draft-js": "^0.8.1",
+    "@wix/draft-js": "^0.8.1",
     "eslint": "3.12.0",
     "eslint-config-hubspot": "^7.0.0",
     "eslint-config-prettier": "^2.2.0",

--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -19,7 +19,7 @@ import {
   BlockMapBuilder,
   genKey,
   SelectionState,
-} from 'draft-js';
+} from '@wix/draft-js';
 import getSafeBodyFromHTML from './util/parseHTML';
 import rangeSort from './util/rangeSort';
 

--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -2,7 +2,7 @@
 import invariant from 'invariant';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import { convertToRaw } from 'draft-js';
+import { convertToRaw } from '@wix/draft-js';
 
 import encodeBlock from './encodeBlock';
 import blockEntities from './blockEntities';

--- a/test/spec/blockEntities-test.js
+++ b/test/spec/blockEntities-test.js
@@ -3,7 +3,7 @@ import blockInlineStyles from '../../src/blockInlineStyles';
 import encodeBlock from '../../src/encodeBlock';
 import { Map } from 'immutable';
 import React from 'react';
-import { convertFromRaw, convertToRaw } from 'draft-js';
+import { convertFromRaw, convertToRaw } from '@wix/draft-js';
 
 const buildRawBlock = (
   text,

--- a/test/spec/blockInlineStyles-test.js
+++ b/test/spec/blockInlineStyles-test.js
@@ -1,6 +1,6 @@
 import blockInlineStyles from '../../src/blockInlineStyles';
 import React from 'react';
-import { convertFromRaw, convertToRaw } from 'draft-js';
+import { convertFromRaw, convertToRaw } from '@wix/draft-js';
 
 const buildRawBlock = (text, styleRanges) => {
   return convertToRaw(

--- a/test/spec/convertFromHTML-test.js
+++ b/test/spec/convertFromHTML-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Entity, convertToRaw } from 'draft-js';
+import { Entity, convertToRaw } from '@wix/draft-js';
 import convertFromHTML from '../../src/convertFromHTML';
 import convertToHTML from '../../src/convertToHTML';
 

--- a/test/spec/convertToHTML-test.js
+++ b/test/spec/convertToHTML-test.js
@@ -1,6 +1,6 @@
 import convertToHTML from '../../src/convertToHTML';
 import React from 'react';
-import { convertFromRaw } from 'draft-js';
+import { convertFromRaw } from '@wix/draft-js';
 import uniqueId from '../util/uniqueId';
 
 /* eslint-disable react/no-multi-comp */


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.303s
error Couldn't find any versions for "@wix/draft-js" that matches "^0.8.1"
(node:6706) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: yarn
    at makeError (/app/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:6706) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:6706) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.



Output Log:
Migrating package "draft-convert" in .


## Migration from non scope to @wix/scoped packages
> /tmp/081dcdd8ce817f6c2e3848637d1c8c04

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/convertFromHTML.js
src/convertToHTML.js
test/spec/blockEntities-test.js
test/spec/blockInlineStyles-test.js
test/spec/convertFromHTML-test.js
test/spec/convertToHTML-test.js
```
yarn install v1.22.5
[1/4] Resolving packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

